### PR TITLE
Swapped docker images

### DIFF
--- a/dockerfiles/dockerfile-ai
+++ b/dockerfiles/dockerfile-ai
@@ -5,7 +5,7 @@ WORKDIR /aurora
 RUN chmod +x ./mvnw && \
     ./mvnw clean package -DskipTests
 
-FROM amazoncorretto:21-alpine3.22-jre
+FROM amazoncorretto:21-al2023-headless
 COPY --from=build /aurora/target/aurora-ai-*.jar /aurora/aurora-ai.jar
 CMD ["java", "-jar", "/aurora/aurora-ai.jar"]
 EXPOSE 8082

--- a/dockerfiles/dockerfile-auth
+++ b/dockerfiles/dockerfile-auth
@@ -5,7 +5,7 @@ WORKDIR /aurora
 RUN chmod +x ./mvnw && \
     ./mvnw clean package -DskipTests
 
-FROM amazoncorretto:21-alpine3.22-jre
+FROM amazoncorretto:21-al2023-headless
 COPY --from=build /aurora/target/aurora-auth-*.jar /aurora/aurora-auth.jar
 CMD ["java", "-jar", "/aurora/aurora-auth.jar"]
 EXPOSE 8083

--- a/dockerfiles/dockerfile-core
+++ b/dockerfiles/dockerfile-core
@@ -5,7 +5,7 @@ WORKDIR /aurora
 RUN chmod +x ./mvnw && \
     ./mvnw clean package -DskipTests
 
-FROM amazoncorretto:21-alpine3.22-jre
+FROM amazoncorretto:21-al2023-headless
 COPY --from=build /aurora/target/aurora-core-*.jar /aurora/aurora-core.jar
 CMD ["java", "-jar", "/aurora/aurora-core.jar"]
 EXPOSE 8081


### PR DESCRIPTION
This pull request updates the base image used in several Dockerfiles to improve compatibility and potentially reduce image size and resource usage. The main change is switching from the `amazoncorretto:21-alpine3.22-jre` image to the `amazoncorretto:21-al2023-headless` image for all Java service containers.

Docker image updates:

* Changed the base image in `dockerfiles/dockerfile-ai` from `amazoncorretto:21-alpine3.22-jre` to `amazoncorretto:21-al2023-headless` for the AI service.
* Changed the base image in `dockerfiles/dockerfile-auth` from `amazoncorretto:21-alpine3.22-jre` to `amazoncorretto:21-al2023-headless` for the Auth service.
* Changed the base image in `dockerfiles/dockerfile-core` from `amazoncorretto:21-alpine3.22-jre` to `amazoncorretto:21-al2023-headless` for the Core service.