### PR TITLE
Optimized size of profile images

### DIFF
--- a/aurora-core/pom.xml
+++ b/aurora-core/pom.xml
@@ -1,4 +1,4 @@
- <?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -137,6 +137,12 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.coobird</groupId>
+            <artifactId>thumbnailator</artifactId>
+            <version>0.4.21</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/exception/InvalidBase64Exception.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/exception/InvalidBase64Exception.kt
@@ -1,0 +1,3 @@
+package pl.dayfit.auroracore.exception
+
+class InvalidBase64Exception(message: String) : Exception(message)

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/exceptionhandler/GlobalExceptionHandler.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/exceptionhandler/GlobalExceptionHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import pl.dayfit.auroracore.exception.AutoGenerationFailedException
+import pl.dayfit.auroracore.exception.InvalidBase64Exception
 import pl.dayfit.auroracore.exception.ResourceNotReadyYetException
 import pl.dayfit.auroracore.exception.UuidInvalidException
 import java.security.NoSuchProviderException
@@ -103,6 +104,12 @@ class GlobalExceptionHandler {
         logger.trace("Requested resource not found: ", e)
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(mapOf("error" to (e.message ?: "Requested resource not found")))
+    }
+
+    @ExceptionHandler(InvalidBase64Exception::class)
+    fun handleInvalidBase64Exception(e: InvalidBase64Exception): ResponseEntity<Map<String, String>> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(mapOf("error" to (e.message ?: "Invalid base64 string")))
     }
 
     @ExceptionHandler(Exception::class)

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/service/GenerationService.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/service/GenerationService.kt
@@ -10,6 +10,7 @@ import com.itextpdf.styledxmlparser.css.media.MediaType
 import freemarker.template.Configuration
 import freemarker.template.Template
 import jakarta.transaction.Transactional
+import net.coobird.thumbnailator.Thumbnails
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.rabbit.stream.producer.RabbitStreamTemplate
@@ -106,7 +107,16 @@ class GenerationService(
                     it.year
                 )
             }.toMutableList(),
-            requestDto.profileImage?.let { Base64.decode(it) },
+            requestDto.profileImage?.let {
+                val inputStream = ByteArrayInputStream(Base64.decode(it))
+                val outputStream = ByteArrayOutputStream()
+                Thumbnails.of(inputStream)
+                    .outputQuality(0.75)
+                    .size(600, 600)
+                    .toOutputStream(outputStream)
+
+                return@let outputStream.toByteArray()
+            },
 
             requestDto.profileDescription,
             requestDto.email,


### PR DESCRIPTION
This pull request introduces image processing functionality to the `GenerationService` by resizing and compressing profile images before further handling. The main change is the integration of the `thumbnailator` library, which enables efficient image manipulation. Below are the most important changes:

**Image processing enhancements:**

* Added the `thumbnailator` dependency to `aurora-core/pom.xml` to enable image resizing and compression features.
* Updated the profile image handling logic in `GenerationService.kt` to resize profile images to 600x600 pixels and compress them to 75% quality using the `Thumbnails` API.
* Imported `net.coobird.thumbnailator.Thumbnails` in `GenerationService.kt` to support the new image processing logic.

Image sized in example request image size was around 29 MB, after adding thumbnailator, size went down to around 500KB, while still being sharp and crispy.