### PR TITLE
Multipart file impl

### DIFF
--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/controller/ResumeController.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/controller/ResumeController.kt
@@ -121,7 +121,7 @@ class ResumeController (
      */
     @PostMapping("/generate", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun generate(@RequestPart("requestDto") requestDto: GenerationRequestDto,
-                 @RequestPart("image") file: MultipartFile,
+                 @RequestPart("image") file: MultipartFile?,
                  @AuthenticationPrincipal principal: Principal
     ): ResponseEntity<Map<String, String>> {
         val resumeId = generationService.requestGeneration(

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/controller/ResumeController.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/controller/ResumeController.kt
@@ -120,7 +120,7 @@ class ResumeController (
      */
     @PostMapping("/generate")
     fun generate(@RequestBody requestDto: GenerationRequestDto,
-                 @RequestParam("file") file: MultipartFile,
+                 @RequestParam("image") file: MultipartFile,
                  @AuthenticationPrincipal principal: Principal
     ): ResponseEntity<Map<String, String>> {
         val resumeId = generationService.requestGeneration(
@@ -165,7 +165,7 @@ class ResumeController (
      */
     @PatchMapping("/edit")
     fun edit(@RequestBody editDto: EditResumeDto,
-             @RequestParam("file") file: MultipartFile?,
+             @RequestParam("image") file: MultipartFile?,
              @AuthenticationPrincipal principal: Principal?
     ): ResponseEntity<Map<String, String>>
     {

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/controller/ResumeController.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/controller/ResumeController.kt
@@ -164,10 +164,14 @@ class ResumeController (
      *         and the value is a confirmation that the résumé was successfully edited
      */
     @PatchMapping("/edit")
-    fun edit(@RequestBody editDto: EditResumeDto, @AuthenticationPrincipal principal: Principal?): ResponseEntity<Map<String, String>>
+    fun edit(@RequestBody editDto: EditResumeDto,
+             @RequestParam("file") file: MultipartFile?,
+             @AuthenticationPrincipal principal: Principal?
+    ): ResponseEntity<Map<String, String>>
     {
         resumeService.processEdit(
             editDto,
+            file,
             UUID.fromString(
                 principal?.name
             )

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/controller/ResumeController.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/controller/ResumeController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
 import pl.dayfit.auroracore.dto.EditResumeDto
 import pl.dayfit.auroracore.dto.GenerationRequestDto
@@ -118,9 +119,13 @@ class ResumeController (
      *
      */
     @PostMapping("/generate")
-    fun generate(@RequestBody requestDto: GenerationRequestDto, @AuthenticationPrincipal principal: Principal): ResponseEntity<Map<String, String>> {
+    fun generate(@RequestBody requestDto: GenerationRequestDto,
+                 @RequestParam("file") file: MultipartFile,
+                 @AuthenticationPrincipal principal: Principal
+    ): ResponseEntity<Map<String, String>> {
         val resumeId = generationService.requestGeneration(
             requestDto,
+            file,
             UUID.fromString(
                 principal.name
             )

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/controller/ResumeController.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/controller/ResumeController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
@@ -118,9 +119,9 @@ class ResumeController (
      * @return a ResponseEntity containing a map with a single entry where the key is "resumeId" and the value is a string representation of the newly generated résumé's unique identifier
      *
      */
-    @PostMapping("/generate")
-    fun generate(@RequestBody requestDto: GenerationRequestDto,
-                 @RequestParam("image") file: MultipartFile,
+    @PostMapping("/generate", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun generate(@RequestPart("requestDto") requestDto: GenerationRequestDto,
+                 @RequestPart("image") file: MultipartFile,
                  @AuthenticationPrincipal principal: Principal
     ): ResponseEntity<Map<String, String>> {
         val resumeId = generationService.requestGeneration(
@@ -163,9 +164,9 @@ class ResumeController (
      * @return a ResponseEntity containing a map with a single entry where the key is "message"
      *         and the value is a confirmation that the résumé was successfully edited
      */
-    @PatchMapping("/edit")
-    fun edit(@RequestBody editDto: EditResumeDto,
-             @RequestParam("image") file: MultipartFile?,
+    @PatchMapping("/edit", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun edit(@RequestPart("requestDto") editDto: EditResumeDto,
+             @RequestPart("image", required = false) file: MultipartFile?,
              @AuthenticationPrincipal principal: Principal?
     ): ResponseEntity<Map<String, String>>
     {

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/dto/EditResumeDto.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/dto/EditResumeDto.kt
@@ -30,8 +30,6 @@ data class EditResumeDto(
     val linkedIn: String?,
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val gitHub: String?,
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    val profileImage: String?,
     @Length(max = 2000)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val profileDescription: String?,

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/dto/GenerationRequestDto.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/dto/GenerationRequestDto.kt
@@ -24,7 +24,6 @@ data class GenerationRequestDto (
     val website: String?,
     val linkedIn: String?,
     val gitHub: String?,
-    val profileImage: String?,
     val profileDescription: String?,
     val education: List<Education>,
     val skills: List<Skill>,

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/helper/ImageCompressorHelper.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/helper/ImageCompressorHelper.kt
@@ -1,0 +1,42 @@
+package pl.dayfit.auroracore.helper
+
+import net.coobird.thumbnailator.Thumbnails
+import org.springframework.stereotype.Component
+import pl.dayfit.auroracore.exception.InvalidBase64Exception
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+
+@Component
+class ImageCompressorHelper {
+    private val imageQuality = 0.75
+    private val profileImageSize = 600
+
+     fun compressProfileImage(fileStream: InputStream): ByteArray {
+         try {
+             val outputStream = ByteArrayOutputStream()
+             Thumbnails.of(fileStream)
+                 .outputQuality(imageQuality)
+                 .size(profileImageSize, profileImageSize)
+                 .keepAspectRatio(true)
+                 .toOutputStream(outputStream)
+
+             return outputStream.toByteArray()
+         } catch (_: IllegalArgumentException) {
+             throw InvalidBase64Exception("Profile image is invalid base64 string")
+         }
+     }
+
+    fun compressPreview(image: BufferedImage): ByteArray
+    {
+        ByteArrayOutputStream().use { tmpOutput ->
+            Thumbnails.of(image)
+                .size(595, 842)
+                .outputQuality(imageQuality)
+                .outputFormat("png")
+                .toOutputStream(tmpOutput)
+
+            return tmpOutput.toByteArray()
+        }
+    }
+}

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/service/GenerationService.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/service/GenerationService.kt
@@ -68,7 +68,7 @@ class GenerationService(
      * @return The unique identifier of the generated résumé.
      */
     @Transactional
-    fun requestGeneration(requestDto: GenerationRequestDto, file: MultipartFile, userId: UUID): UUID
+    fun requestGeneration(requestDto: GenerationRequestDto, file: MultipartFile?, userId: UUID): UUID
     {
         val resume = Resume(
             null,
@@ -118,8 +118,8 @@ class GenerationService(
                     it.year
                 )
             }.toMutableList(),
-            imageHelper.compressProfileImage(file.inputStream),
-
+            file?.inputStream
+                ?.use { imageHelper.compressProfileImage(it) },
             null,
             requestDto.profileDescription,
             requestDto.email,

--- a/aurora-core/src/main/resources/application.properties
+++ b/aurora-core/src/main/resources/application.properties
@@ -35,3 +35,5 @@ information.handlers.github-pat=${GITHUB_PAT:}
 minio.endpoint=${MINIO_HOST}:9000
 minio.username=${MINIO_ACCESS_KEY}
 minio.password=${MINIO_SECRET_KEY}
+
+spring.servlet.multipart.max-file-size=10MB

--- a/aurora-front/src/components/cv-components/get-changed-fields.tsx
+++ b/aurora-front/src/components/cv-components/get-changed-fields.tsx
@@ -1,10 +1,14 @@
-import { fileToBase64 } from "@/lib/utils/image";
+export interface ChangedFieldsResult {
+  changes: any;
+  profileImageChanged: boolean;
+}
 
 export async function getChangedFields(
   originalData: any,
   newData: any,
-): Promise<any> {
+): Promise<ChangedFieldsResult> {
   const changes: any = {};
+  let profileImageChanged = false;
 
   // Handle simple fields
   const simpleFields = [
@@ -26,13 +30,11 @@ export async function getChangedFields(
     }
   }
 
-  // Handle profileImage specially
+  // Handle profileImage specially - check if it changed but don't include in changes
+  // The File object will be passed separately as multipart
   if (newData.profileImage instanceof File) {
-    // Convert File to base64 for comparison and submission
-    const newImageBase64 = await fileToBase64(newData.profileImage);
-    if (originalData?.profileImage !== newImageBase64) {
-      changes.profileImage = newImageBase64;
-    }
+    // A new file was selected, so it's always considered changed
+    profileImageChanged = true;
   } else if (newData.profileImage === null && originalData?.profileImage) {
     changes.profileImage = null;
   }
@@ -55,5 +57,5 @@ export async function getChangedFields(
     }
   }
 
-  return changes;
+  return { changes, profileImageChanged };
 }

--- a/aurora-front/src/lib/backend/backend.ts
+++ b/aurora-front/src/lib/backend/backend.ts
@@ -9,6 +9,8 @@ import { cookies } from "next/headers";
 import { parseBearerToken } from "@/lib/utils/parse-bearer-token";
 import { ApiService, getServiceBaseUrl } from "@/lib/backend/api-config";
 
+const APPLICATION_JSON = "application/json";
+
 export async function callBackend<T = any>({
   method = RequestMethod.POST,
   endpoint,
@@ -88,7 +90,7 @@ export async function callBackend<T = any>({
     // ONLY add Content-Type if we are actually sending a body and not using FormData
     // When using FormData, browser will set Content-Type with correct boundary automatically
     if (body && method !== RequestMethod.GET && !file) {
-      headers["Content-Type"] = "application/json";
+      headers["Content-Type"] = APPLICATION_JSON;
     }
     return headers;
   };
@@ -100,7 +102,7 @@ export async function callBackend<T = any>({
       if (body) {
         formData.append(
           "requestDto",
-          new Blob([JSON.stringify(body)], { type: "application/json" }),
+          new Blob([JSON.stringify(body)], { type: APPLICATION_JSON }),
         );
       }
       return formData;

--- a/aurora-front/src/lib/backend/backend.ts
+++ b/aurora-front/src/lib/backend/backend.ts
@@ -14,6 +14,7 @@ export async function callBackend<T = any>({
   endpoint,
   body = null,
   service = ApiService.AUTH,
+  file = null,
 }: RequestType): Promise<BackendResponse<T>> {
   const host = getServiceBaseUrl(service);
   const protocol = process.env.NODE_ENV === "production" ? "https://" : "http://";
@@ -84,11 +85,27 @@ export async function callBackend<T = any>({
         headers.Authorization = `Bearer ${accessToken}`;
       }
     }
-    // ONLY add Content-Type if we are actually sending a body
-    if (body && method !== RequestMethod.GET) {
+    // ONLY add Content-Type if we are actually sending a body and not using FormData
+    // When using FormData, browser will set Content-Type with correct boundary automatically
+    if (body && method !== RequestMethod.GET && !file) {
       headers["Content-Type"] = "application/json";
     }
     return headers;
+  };
+
+  const buildRequestBody = (): FormData | string | undefined => {
+    if (file) {
+      const formData = new FormData();
+      formData.append("image", file);
+      if (body) {
+        formData.append(
+          "requestDto",
+          new Blob([JSON.stringify(body)], { type: "application/json" }),
+        );
+      }
+      return formData;
+    }
+    return body ? JSON.stringify(body) : undefined;
   };
 
   const url = `${BASE_URL.replace(/\/$/, "")}/${endpoint.replace(/^\//, "")}`;
@@ -96,7 +113,7 @@ export async function callBackend<T = any>({
   let res = await fetch(url, {
     method,
     headers: getHeaders(),
-    body: body ? JSON.stringify(body) : undefined,
+    body: buildRequestBody(),
     cache: "no-store",
   });
 
@@ -131,7 +148,7 @@ export async function callBackend<T = any>({
           res = await fetch(url, {
             method,
             headers: getHeaders(),
-            body: body ? JSON.stringify(body) : undefined,
+            body: buildRequestBody(),
             cache: "no-store",
           });
           applySetCookieHeader(res.headers.get("set-cookie"));

--- a/aurora-front/src/lib/backend/edit-resume.ts
+++ b/aurora-front/src/lib/backend/edit-resume.ts
@@ -4,7 +4,11 @@ import { callBackend } from "@/lib/backend/backend";
 import { RequestMethod } from "@/lib/types/backend";
 import { ApiService } from "@/lib/backend/api-config";
 
-export async function editResume(resumeId: string, changes: any) {
+export async function editResume(
+  resumeId: string,
+  changes: any,
+  profileImage: File | null = null,
+) {
   return await callBackend({
     endpoint: "/api/v1/core/resume/edit",
     method: RequestMethod.PATCH,
@@ -13,5 +17,6 @@ export async function editResume(resumeId: string, changes: any) {
       ...changes,
     },
     service: ApiService.CORE,
+    file: profileImage,
   });
 }

--- a/aurora-front/src/lib/backend/resume-generation.ts
+++ b/aurora-front/src/lib/backend/resume-generation.ts
@@ -4,11 +4,12 @@ import { callBackend } from "@/lib/backend/backend";
 import { RequestMethod } from "@/lib/types/backend";
 import { ApiService } from "@/lib/backend/api-config";
 
-export async function generateResume(data: any) {
+export async function generateResume(data: any, profileImage: File | null) {
   return await callBackend({
     endpoint: "/api/v1/core/resume/generate",
     method: RequestMethod.POST,
     body: data,
     service: ApiService.CORE,
+    file: profileImage,
   });
 }

--- a/aurora-front/src/lib/types/backend.ts
+++ b/aurora-front/src/lib/types/backend.ts
@@ -17,4 +17,5 @@ export interface RequestType {
   method?: RequestMethod;
   endpoint: string;
   service?: ApiService;
+  file?: File | null;
 }


### PR DESCRIPTION
This pull request introduces a refactor to how profile images are handled for resume generation and editing. The main change is moving from passing profile image data as a string in DTOs to accepting image files directly via multipart requests. This enables image compression and validation to be handled consistently in a new helper class, improving reliability and maintainability.

**Profile Image Handling Refactor**

* The `GenerationRequestDto` and `EditResumeDto` classes no longer contain a `profileImage` string field; instead, profile images are now uploaded as files in the corresponding controller endpoints. [[1]](diffhunk://#diff-1c187a085bb5c3417b5942de171b9d5657204cefb3a8c3510fcad4e8066320a5L27) [[2]](diffhunk://#diff-15cb0e218fad8434aebb9769a3d0da516b9402bc049635d12bdcf98a33145d9eL33-L34)
* The `ResumeController`'s `/generate` and `/edit` endpoints have been updated to accept a `MultipartFile` for the profile image, and pass it to the service layer for processing. [[1]](diffhunk://#diff-ccd6ce65ebe4500f7179ca901724135c4de233d7d284334442cf8e15942caaf8L121-R128) [[2]](diffhunk://#diff-ccd6ce65ebe4500f7179ca901724135c4de233d7d284334442cf8e15942caaf8L162-R174)

**Image Compression and Validation**

* A new `ImageCompressorHelper` component was added, centralizing image compression logic for profile images and previews, and replacing previous inline image processing code.
* The `GenerationService` and `ResumeService` classes now use `ImageCompressorHelper` to process uploaded profile images and generate compressed preview images, removing legacy code that handled base64 image strings. [[1]](diffhunk://#diff-5243b3aa8fe9447816dade8e904d5b6d1bf89aec862a76746bc0593b990a101aR53-L56) [[2]](diffhunk://#diff-5243b3aa8fe9447816dade8e904d5b6d1bf89aec862a76746bc0593b990a101aL121-R121) [[3]](diffhunk://#diff-5243b3aa8fe9447816dade8e904d5b6d1bf89aec862a76746bc0593b990a101aL288-L324) [[4]](diffhunk://#diff-c88c6d55a192d5b1d2ec0d6950f17081043a25ad082d09cf4ff1396bfb3f3375R50) [[5]](diffhunk://#diff-c88c6d55a192d5b1d2ec0d6950f17081043a25ad082d09cf4ff1396bfb3f3375L212-R215) [[6]](diffhunk://#diff-c88c6d55a192d5b1d2ec0d6950f17081043a25ad082d09cf4ff1396bfb3f3375R225-R231)

**Configuration Updates**

* The maximum allowed multipart file size for uploads is now set to 10MB in `application.properties`.