### PR TITLE
Fixed a case when resume's child were not detached

### DIFF
--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="file://$PROJECT_DIR$/aurora-core/src/main/kotlin/pl/dayfit/auroracore/model/Resume.kt" dialect="GenericSQL" />
+    <file url="PROJECT" dialect="PostgreSQL" />
+  </component>
+</project>

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/configuration/RedisConfiguration.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/configuration/RedisConfiguration.kt
@@ -1,25 +1,8 @@
 package pl.dayfit.auroracore.configuration
 
-import org.springframework.cache.CacheManager
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.data.redis.cache.RedisCacheManager
-import org.springframework.data.redis.connection.RedisConnectionFactory
-import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
 
 @Configuration
 @EnableRedisRepositories(basePackages = ["pl.dayfit.auroracore.repository.redis"])
-class RedisConfiguration {
-    @Bean
-    fun cacheManager(
-        redisConnectionFactory: RedisConnectionFactory
-    ): CacheManager = RedisCacheManager.create(redisConnectionFactory)
-
-    @Bean
-    fun redisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, Any>{
-        val redisTemplate = RedisTemplate<String, Any>()
-        redisTemplate.connectionFactory = (connectionFactory)
-        return redisTemplate
-    }
-}
+class RedisConfiguration

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/model/Resume.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/model/Resume.kt
@@ -14,7 +14,7 @@ import java.time.Instant
 import java.util.UUID
 
 @Entity
-@SQLDelete(sql = "UPDATE resume SET parent_id = NULL WHERE parent_id = id")
+@SQLDelete(sql = "WITH updated AS (UPDATE resume SET parent_id = NULL WHERE parent_id = ?) DELETE FROM resume WHERE id = ?")
 class Resume(
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/aurora-core/src/main/kotlin/pl/dayfit/auroracore/model/Resume.kt
+++ b/aurora-core/src/main/kotlin/pl/dayfit/auroracore/model/Resume.kt
@@ -8,21 +8,21 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
+import org.hibernate.annotations.SQLDelete
 import pl.dayfit.auroracore.type.LanguageType
 import java.time.Instant
 import java.util.UUID
 
 @Entity
+@SQLDelete(sql = "UPDATE resume SET parent_id = NULL WHERE parent_id = id")
 class Resume(
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     var id: UUID?,
     var auroraUserId: UUID,
     var language: LanguageType?,
-
     @ManyToOne(cascade = [CascadeType.DETACH])
     var originalVersion: Resume?,
-
     var name: String,
     var surname: String,
     @Column(length = 200)


### PR DESCRIPTION
This pull request introduced a fix to issue when a backend removes a parent without removing its references in child.
Now before removing an entity SQL prompt is called: `UPDATE resume SET original_version_id = NULL WHERE original_version_id = ?`